### PR TITLE
Exposes previous X and previous Y in callback 

### DIFF
--- a/src/implosion.js
+++ b/src/implosion.js
@@ -20,22 +20,21 @@ const requestAnimFrame = (function() {
 	);
 })();
 
-function getPassiveSupported() {
-	let passiveSupported = false;
+const passiveSupported = (() => {
+	let _passiveSupported = false;
 
 	try {
 		let options = Object.defineProperty({}, 'passive', {
 			get: function() {
-				passiveSupported = true;
+				_passiveSupported = true;
 			},
 		});
 
 		window.addEventListener('test', null, options);
 	} catch (err) {}
 
-	getPassiveSupported = () => passiveSupported;
-	return passiveSupported;
-}
+	return _passiveSupported;
+})();
 
 class Implosion {
 	constructor({
@@ -192,10 +191,10 @@ class Implosion {
 		 */
 		function cleanUpRuntimeEvents() {
 			// Remove all touch events added during 'onDown' as well.
-			document.removeEventListener('touchmove', onMove, getPassiveSupported() ? { passive: false } : false);
+			document.removeEventListener('touchmove', onMove, passiveSupported ? { passive: false } : false);
 			document.removeEventListener('touchend', onUp);
 			document.removeEventListener('touchcancel', stopTracking);
-			document.removeEventListener('mousemove', onMove, getPassiveSupported() ? { passive: false } : false);
+			document.removeEventListener('mousemove', onMove, passiveSupported ? { passive: false } : false);
 			document.removeEventListener('mouseup', onUp);
 		}
 
@@ -206,10 +205,10 @@ class Implosion {
 			cleanUpRuntimeEvents();
 
 			// @see https://developers.google.com/web/updates/2017/01/scrolling-intervention
-			document.addEventListener('touchmove', onMove, getPassiveSupported() ? { passive: false } : false);
+			document.addEventListener('touchmove', onMove, passiveSupported ? { passive: false } : false);
 			document.addEventListener('touchend', onUp);
 			document.addEventListener('touchcancel', stopTracking);
-			document.addEventListener('mousemove', onMove, getPassiveSupported() ? { passive: false } : false);
+			document.addEventListener('mousemove', onMove, passiveSupported ? { passive: false } : false);
 			document.addEventListener('mouseup', onUp);
 		}
 

--- a/src/implosion.js
+++ b/src/implosion.js
@@ -60,6 +60,8 @@ class Implosion {
 			decVelY;
 		let targetX = 0;
 		let targetY = 0;
+		let prevTargetX = null;
+		let prevTargetY = null;
 		let stopThreshold = stopThresholdDefault * multiplier;
 		let ticking = false;
 		let pointerActive = false;
@@ -216,7 +218,9 @@ class Implosion {
 		 * Executes the update function
 		 */
 		function callUpdateCallback() {
-			updateCallback.call(sourceEl, targetX, targetY);
+			updateCallback.call(sourceEl, targetX, targetY, prevTargetX, prevTargetY);
+			prevTargetX = targetX;
+			prevTargetY = targetY;
 		}
 
 		/**


### PR DESCRIPTION
> Same change as https://github.com/chrisbateman/impetus/pull/43

In my case, I didn't just want absolute X and Y values, but wanted to see how those X and Y values had _changed_ since the last callback.

By exposing the previous X and Y values in our callback via two new arguments, I can now calculate these deltas. For example:

```js
new Impetus({
    source: '#some-element',
    update: function(x, y, px, py) {
        console.log('x ', x);
        console.log('y ', y);
        console.log('previous x ', px);
        console.log('previous y ', py);
        console.log('change in x ', x - px);
        console.log('change in y ', y - py);
    }
});
```