### PR TITLE
Correctly names library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Implosion.js
+# Impulsion.js
 
 > Fork of the excellent [impetus.js](https://github.com/chrisbateman/impetus) by Chris Bateman.
 
@@ -6,21 +6,21 @@ Add momentum to anything. It's like iScroll, except not for scrolling. Supports 
 
 Check out the demos on the [home page](http://romellem.github.io/impulsion).
 
-Implosion will probably never support anything other than simple momentum. If you need scrolling or touch carousels or anything like that, this probably isn't the tool you're looking for.
+Impulsion will probably never support anything other than simple momentum. If you need scrolling or touch carousels or anything like that, this probably isn't the tool you're looking for.
 
 ## Installation
 
 ```
-yarn add implosion
-# or npm install implosion
+yarn add impulsion
+# or npm install impulsion
 ```
 
 ### Usage
 ```javascript
-import Implosion from 'implosion';
-// const Implosion = require('implosion');
+import Impulsion from 'impulsion';
+// const Impulsion = require('impulsion');
 
-let myImplosion = new Implosion({
+let myImpulsion = new Impulsion({
     source: myNode,
     onUpdate(x, y, previousX, previousY) {
         // whatever you want to do with the values
@@ -30,7 +30,7 @@ let myImplosion = new Implosion({
 
 You give it an area to listen to for touch or mouse events, and it gives you the `x` and `y` values with some momentum.
 
-Implosion will register itself as an AMD module if it's available.
+Impulsion will register itself as an AMD module if it's available.
 
 ### Constructor Options
 <table>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<title>Implosion.js - Add Momentum to Anything</title>
+	<title>Impulsion.js - Add Momentum to Anything</title>
 	<meta name="keywords" content="JavaScript, JS, Momentum" />
 	<link href='//fonts.googleapis.com/css?family=Raleway:100' rel='stylesheet' type='text/css'>
 	<style>
@@ -162,11 +162,11 @@
 <body>
 	<header>
 		<div class="container">
-			<h1>Implosion.js</h1>
+			<h1>Impulsion.js</h1>
 			<p>Add momentum to anything. It's like iScroll, except not for scrolling. Supports mouse and touch events. Less than 1.5KB gzipped.</p>
 			<div>
-				<a class="button" href="https://github.com/romellem/implosion">View on GitHub</a>
-				<a class="button" href="https://unpkg.com/implosion/dist/implosion.min.js">Download</a>
+				<a class="button" href="https://github.com/romellem/impulsion">View on GitHub</a>
+				<a class="button" href="https://unpkg.com/impulsion/dist/impulsion.min.js">Download</a>
 			</div>
 		</div>
 	</header>
@@ -178,15 +178,15 @@
 	</div>
 	<div class="info-area">
 		<div class="container">
-		    <p>Implosion is meant to be used as a part of other components &mdash; these simple demos just demonstrate the momentum. For an example of a practical implementation, take a look at <a href="http://romellem.github.io/spherical/">Spherical.js</a>.</p>
+		    <p>Impulsion is meant to be used as a part of other components &mdash; these simple demos just demonstrate the momentum. For an example of a practical implementation, take a look at <a href="http://romellem.github.io/spherical/">Spherical.js</a>.</p>
 	        <h2>Usage</h2>
-			<pre><code>new Implosion({
+			<pre><code>new impulsion({
     source: myNode,
     update: function(x, y) {
         // whatever you want to do with the values
     }
 });</code></pre>
-			<p>For more usage details, see the <a href="https://github.com/romellem/implosion">API</a> on GitHub.</p>
+			<p>For more usage details, see the <a href="https://github.com/romellem/impulsion">API</a> on GitHub.</p>
 		</div>
 	</div>
 
@@ -196,12 +196,12 @@
 		</div>
 	</footer>
 
-	<script src="implosion.js"></script>
+	<script src="impulsion.js"></script>
 	<script>
 	var dotEl = document.getElementById('Dot');
 	var dotParent = dotEl.offsetParent;
 
-	var dotImplosion = new Implosion({
+	var dotImpulsion = new Impulsion({
 		source: dotEl,
 		initialValues: [dotParent.offsetWidth/2 - 25, 45],
 		boundX: [0, dotParent.offsetWidth - dotEl.offsetWidth],
@@ -212,7 +212,7 @@
 		}
 	});
 
-	new Implosion({
+	new Impulsion({
 		source: '#Cube',
 		multiplier: 0.7,
 		update: function(x, y) {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "implosion",
+  "name": "impulsion",
   "version": "0.10.1",
-  "main": "dist/implosion.js",
-  "homepage": "http://romellem.github.io/implosion/",
+  "main": "dist/impulsion.js",
+  "homepage": "http://romellem.github.io/impulsion/",
   "description": "Add momentum to anything. It's like iScroll, except not for scrolling. Supports mouse and touch events.",
   "scripts": {
     "prebuild": "node scripts/prebuild.js",
@@ -21,10 +21,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git@github.com:romellem/implosion.git"
+    "url": "git@github.com:romellem/impulsion.git"
   },
   "bugs": {
-    "url": "https://github.com/romellem/implosion/issues"
+    "url": "https://github.com/romellem/impulsion/issues"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,6 +30,6 @@ const makeRollupConfig = (globalObjectName, inputFile, outputFile) => {
 };
 
 export default [
-	makeRollupConfig('Implosion', 'src/implosion.js', 'dist/implosion.js'),
-	makeRollupConfig('Implosion', 'src/implosion.js', 'dist/implosion.min.js'),
+	makeRollupConfig('Impulsion', 'src/impulsion.js', 'dist/impulsion.js'),
+	makeRollupConfig('Impulsion', 'src/impulsion.js', 'dist/impulsion.min.js'),
 ];

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,6 +1,6 @@
 const fs = require('fs-extra');
 const path = require('path');
 
-const dist_file = path.resolve(__dirname, '../dist/implosion.js');
-const docs_file = path.resolve(__dirname, '../docs/implosion.js');
+const dist_file = path.resolve(__dirname, '../dist/impulsion.js');
+const docs_file = path.resolve(__dirname, '../docs/impulsion.js');
 fs.copySync(dist_file, docs_file);

--- a/src/impulsion.js
+++ b/src/impulsion.js
@@ -36,7 +36,7 @@ const passiveSupported = (() => {
 // @see https://github.com/metafizzy/flickity/issues/457#issuecomment-254501356
 window.addEventListener('touchmove', function() {}, passiveSupported ? { passive: true } : false);
 
-export default class Implosion {
+export default class Impulsion {
 	constructor({
 		source: sourceEl = document,
 		update: updateCallbackDeprecated,
@@ -120,7 +120,7 @@ export default class Implosion {
 
 		/**
 		 * In edge cases where you may need to
-		 * reinstanciate Implosion on the same sourceEl
+		 * reinstanciate Impulsion on the same sourceEl
 		 * this will remove the previous event listeners
 		 */
 		this.destroy = function() {


### PR DESCRIPTION
Honestly am baffled that I did this. I even correctly named it Impulsion
when first creating this repo in Github, but then when I did the mass find/replace, I just choose something that sounded similar I guess.

I have also unpublished the [implosion](https://www.npmjs.com/package/implosion) package, so that name is now free to whoever wants to use it!

To emphasize, "implosion" is **not** and synonym for "impetus."

> ![synonyms-of-impetus](https://user-images.githubusercontent.com/8504000/78275516-4f924c80-74d7-11ea-9df7-c8d8e0832a00.png)
>
> https://www.google.com/search?q=synonym+impetus