### PR TITLE
Sets global touchmove to non-passive

### DIFF
--- a/docs/impulsion.js
+++ b/docs/impulsion.js
@@ -36,7 +36,7 @@
   }();
 
   window.addEventListener('touchmove', function () {}, passiveSupported ? {
-    passive: true
+    passive: false
   } : false);
 
   var Impulsion = function Impulsion(_ref) {

--- a/src/impulsion.js
+++ b/src/impulsion.js
@@ -34,7 +34,7 @@ const passiveSupported = (() => {
 
 // fixes weird safari 10 bug where preventDefault is prevented
 // @see https://github.com/metafizzy/flickity/issues/457#issuecomment-254501356
-window.addEventListener('touchmove', function() {}, passiveSupported ? { passive: true } : false);
+window.addEventListener('touchmove', function() {}, passiveSupported ? { passive: false } : false);
 
 export default class Impulsion {
 	constructor({


### PR DESCRIPTION
Otherwise we really can't prevent default.