### PR TITLE
Feature - Expose hacky 'touchmove' listener to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Impulsion will register itself as an AMD module if it's available.
 			<td><code>true</code></td>
 			<td>Whether to stretch and rebound values when pulled outside the bounds.</td>
 		</tr>
+		<tr>
+			<th scope="row" align="left"><code>addIosTouchmoveFix</code></th>
+			<td><code>Boolean</code></td>
+			<td><code>true</code></td>
+			<td>iOS sometimes fails to <code>preventDefault</code> when scrolling on the body. Per <a href="https://github.com/metafizzy/flickity/issues/457#issuecomment-254501356">this comment</a>, one fix is to add an empty <code>touchmove</code> listener to the main <code>window</code>. This library adds this by default, but if you want to override this hacky listener, it can be disabled by setting this option to <code>false</code>.<br><br>Other information: <ul><li><a href="https://stackoverflow.com/a/49582193">Can't prevent "touchmove" from scrolling window on iOS</a></li><li><a href="https://github.com/facebook/react/issues/9809">touchstart preventDefault() does not prevent click event.</a></li></td>
+		</tr>
 	</tbody>
 </table>
 

--- a/docs/impulsion.js
+++ b/docs/impulsion.js
@@ -53,7 +53,9 @@
         boundX = _ref.boundX,
         boundY = _ref.boundY,
         _ref$bounce = _ref.bounce,
-        bounce = _ref$bounce === void 0 ? true : _ref$bounce;
+        bounce = _ref$bounce === void 0 ? true : _ref$bounce,
+        _ref$addIosTouchmoveF = _ref.addIosTouchmoveFix,
+        addIosTouchmoveFix = _ref$addIosTouchmoveF === void 0 ? true : _ref$addIosTouchmoveF;
 
     _classCallCheck(this, Impulsion);
 
@@ -69,7 +71,7 @@
     var decelerating = false;
     var trackingPoints = [];
 
-    if (!iosNoopTouchmoveAdded) {
+    if (addIosTouchmoveFix && !iosNoopTouchmoveAdded) {
       window.addEventListener('touchmove', function () {}, passiveSupported ? {
         passive: false
       } : false);

--- a/docs/impulsion.js
+++ b/docs/impulsion.js
@@ -35,9 +35,7 @@
     return _passiveSupported;
   }();
 
-  window.addEventListener('touchmove', function () {}, passiveSupported ? {
-    passive: false
-  } : false);
+  var iosNoopTouchmoveAdded = false;
 
   var Impulsion = function Impulsion(_ref) {
     var _ref$source = _ref.source,
@@ -70,6 +68,13 @@
     var paused = false;
     var decelerating = false;
     var trackingPoints = [];
+
+    if (!iosNoopTouchmoveAdded) {
+      window.addEventListener('touchmove', function () {}, passiveSupported ? {
+        passive: false
+      } : false);
+      iosNoopTouchmoveAdded = true;
+    }
 
     (function init() {
       sourceEl = typeof sourceEl === 'string' ? document.querySelector(sourceEl) : sourceEl;

--- a/src/impulsion.js
+++ b/src/impulsion.js
@@ -32,9 +32,8 @@ const passiveSupported = (() => {
 	return _passiveSupported;
 })();
 
-// fixes weird safari 10 bug where preventDefault is prevented
-// @see https://github.com/metafizzy/flickity/issues/457#issuecomment-254501356
-window.addEventListener('touchmove', function() {}, passiveSupported ? { passive: false } : false);
+// Enables us to add the iOS hacky 'touchmove' empty listener fix to the window only once
+let iosNoopTouchmoveAdded = false;
 
 export default class Impulsion {
 	constructor({
@@ -72,6 +71,14 @@ export default class Impulsion {
 		let paused = false;
 		let decelerating = false;
 		let trackingPoints = [];
+
+		if (!iosNoopTouchmoveAdded) {
+			// fixes weird safari 10 bug where preventDefault is prevented
+			// @see https://github.com/metafizzy/flickity/issues/457#issuecomment-254501356
+			window.addEventListener('touchmove', function() {}, passiveSupported ? { passive: false } : false);
+
+			iosNoopTouchmoveAdded = true;
+		}
 
 		/**
 		 * Initialize instance

--- a/src/impulsion.js
+++ b/src/impulsion.js
@@ -49,6 +49,7 @@ export default class Impulsion {
 		boundX,
 		boundY,
 		bounce = true,
+		addIosTouchmoveFix = true,
 	}) {
 		let boundXmin,
 			boundXmax,
@@ -72,7 +73,7 @@ export default class Impulsion {
 		let decelerating = false;
 		let trackingPoints = [];
 
-		if (!iosNoopTouchmoveAdded) {
+		if (addIosTouchmoveFix && !iosNoopTouchmoveAdded) {
 			// fixes weird safari 10 bug where preventDefault is prevented
 			// @see https://github.com/metafizzy/flickity/issues/457#issuecomment-254501356
 			window.addEventListener('touchmove', function() {}, passiveSupported ? { passive: false } : false);


### PR DESCRIPTION
Similar to https://github.com/IMGNRY/impetus/commit/86daa75e7bef7e166f7c4326cba61fb653580a7d in effect, we now:

- Move the no-op `touchmove` listener to inside our class scope, so that if we never call `new Impulsion` this listener is never added.
- Expose a new option, **`addIosTouchmoveFix`**, so that this listener can be disabled by the user. Per current functionality, this option is `true` by default.