### PR TITLE
Chore - Prep for version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Impulsion will register itself as an AMD module if it's available.
 			<th scope="row" align="left"><code>onUpdate</code> (required)</th>
 			<td><code>function(x, y)</code></td>
 			<td>-</td>
-			<td>This function will be called with the updated <var>x</var> and <var>y</var> values. This configuration was renamed from `update`, and `update` has been deprecated, to be removed in the next major version.</td>
+			<td>This function will be called with the updated <var>x</var> and <var>y</var> values.</td>
 		</tr>
 		<tr>
 			<th scope="row" align="left"><code>onStartDecelerating</code></th>

--- a/docs/impulsion.js
+++ b/docs/impulsion.js
@@ -40,7 +40,6 @@
   var Impulsion = function Impulsion(_ref) {
     var _ref$source = _ref.source,
         sourceEl = _ref$source === void 0 ? window : _ref$source,
-        updateCallbackDeprecated = _ref.update,
         updateCallback = _ref.onUpdate,
         startCallback = _ref.onStart,
         startDeceleratingCallback = _ref.onStartDecelerating,
@@ -81,18 +80,14 @@
     }
 
     (function init() {
-      sourceEl = typeof sourceEl === 'string' ? win.querySelector(sourceEl) : sourceEl;
+      sourceEl = typeof sourceEl === 'string' ? document.querySelector(sourceEl) : sourceEl;
 
       if (!sourceEl) {
         throw new Error('IMPETUS: source not found.');
       }
 
-      if (!updateCallback && updateCallbackDeprecated) {
-        updateCallback = updateCallbackDeprecated;
-      }
-
       if (!updateCallback) {
-        throw new Error('IMPETUS: update function not defined.');
+        throw new Error('IMPETUS: onUpdate function not defined.');
       }
 
       if (initialValues) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -182,7 +182,7 @@
 	        <h2>Usage</h2>
 			<pre><code>new impulsion({
     source: myNode,
-    update: function(x, y) {
+    onUpdate: function(x, y, previousX, previousY) {
         // whatever you want to do with the values
     }
 });</code></pre>
@@ -206,7 +206,7 @@
 		initialValues: [dotParent.offsetWidth/2 - 25, 45],
 		boundX: [0, dotParent.offsetWidth - dotEl.offsetWidth],
 		boundY: [0, dotParent.offsetHeight - dotEl.offsetHeight],
-		update: function(x, y) {
+		onUpdate: function(x, y) {
 			this.style.left = x + 'px';
 			this.style.top = y + 'px';
 		}
@@ -215,7 +215,7 @@
 	new Impulsion({
 		source: '#Cube',
 		multiplier: 0.7,
-		update: function(x, y) {
+		onUpdate: function(x, y) {
 			this.style.transform = this.style.webkitTransform = 'translateZ(-120px) rotateY('+x+'deg) rotateX('+(-y)+'deg)';
 		}
 	});

--- a/src/impulsion.js
+++ b/src/impulsion.js
@@ -85,7 +85,7 @@ export default class Impulsion {
 		 * Initialize instance
 		 */
 		(function init() {
-			sourceEl = typeof sourceEl === 'string' ? win.querySelector(sourceEl) : sourceEl;
+			sourceEl = typeof sourceEl === 'string' ? document.querySelector(sourceEl) : sourceEl;
 			if (!sourceEl) {
 				throw new Error('IMPETUS: source not found.');
 			}

--- a/src/impulsion.js
+++ b/src/impulsion.js
@@ -38,7 +38,6 @@ let iosNoopTouchmoveAdded = false;
 export default class Impulsion {
 	constructor({
 		source: sourceEl = window,
-		update: updateCallbackDeprecated,
 		onUpdate: updateCallback,
 		onStart: startCallback,
 		onStartDecelerating: startDeceleratingCallback,
@@ -91,16 +90,8 @@ export default class Impulsion {
 				throw new Error('IMPETUS: source not found.');
 			}
 
-			/**
-			 * Using the `update` configuration is deprecated, us the `onUpdate` key instead
-			 * @deprecated
-			 */
-			if (!updateCallback && updateCallbackDeprecated) {
-				updateCallback = updateCallbackDeprecated;
-			}
-
 			if (!updateCallback) {
-				throw new Error('IMPETUS: update function not defined.');
+				throw new Error('IMPETUS: onUpdate function not defined.');
 			}
 
 			if (initialValues) {


### PR DESCRIPTION
Prep for v1 release, remove deprecated `update` configuration. Now only using `onUpdate` is allowed.

Also, this fixes a bug introduced in #19 when passing in a string for our `source` element. Semver to v1 should also handle this change